### PR TITLE
Bulk update/create Resources from Excel

### DIFF
--- a/TwingateApiClient.mjs
+++ b/TwingateApiClient.mjs
@@ -913,7 +913,7 @@ export class TwingateApiClient {
     }
 
 
-    async createResource(address, alias = null, groupIds = [], isBrowserShortcutEnabled = null, isVisible = null, name, protocols = null, remoteNetworkId, securityPolicyId = null) {
+    async createResource(name, address, remoteNetworkId, protocols = null, groupIds = [], alias = null, isBrowserShortcutEnabled = null, isVisible = null, securityPolicyId = null) {
         const createResourceQuery = "mutation CreateResource($address:String!,$alias:String,$groupIds:[ID],$isBrowserShortcutEnabled:Boolean,$isVisible:Boolean,$name:String!,$protocols:ProtocolsInput,$remoteNetworkId:ID!,$securityPolicyId:ID){result:resourceCreate(address:$address,alias:$alias,groupIds:$groupIds,isBrowserShortcutEnabled:$isBrowserShortcutEnabled,isVisible:$isVisible,name:$name,protocols:$protocols,remoteNetworkId:$remoteNetworkId,securityPolicyId:$securityPolicyId){ok error entity{id name address{value} remoteNetwork{name} groups{edges{node{id name}}}}}}";
         let createResourceResponse = await this.exec(createResourceQuery, {address, alias, groupIds, isBrowserShortcutEnabled, isVisible, name, protocols, remoteNetworkId, securityPolicyId});
         if ( createResourceResponse.result.error !== null ) throw new Error(`Error creating resource: '${createResourceResponse.result.error}'`)

--- a/cliCmd/exportCmd.mjs
+++ b/cliCmd/exportCmd.mjs
@@ -231,6 +231,7 @@ export const exportCmd = new Command()
     .option("-n, --remote-networks [boolean]", "Include Remote Networks")
     .option("-r, --resources [boolean]", "Include Resources")
     .option("-g, --groups [boolean]", "Include Groups")
+    .option("-p, --security-policies [boolean]", "Include Security Policies")
     .option("-u, --users [boolean]", "Include Users")
     .option("-d, --devices [boolean]", "Include Devices (trust)")
     .description("Export from account to various formats")
@@ -244,6 +245,7 @@ export const exportCmd = new Command()
         if ( options.groups === true ) options.typesToFetch.push("Group")
         if ( options.users === true ) options.typesToFetch.push("User")
         if ( options.devices === true ) options.typesToFetch.push("Device")
+        if ( options.securityPolicies === true ) options.typesToFetch.push("SecurityPolicy")
 
         let outputFn = outputFnMap[options.format];
         if (outputFn == null) {

--- a/cliCmd/exportCmd.mjs
+++ b/cliCmd/exportCmd.mjs
@@ -139,14 +139,18 @@ async function outputDot(client, options) {
 async function exportDot(client, options) {
     let dot = await outputDot(client, options);
     options.outputFile = options.outputFile || genFileNameFromNetworkName(options.accountName, options.format);
-    return await Deno.writeTextFile(`./${options.outputFile}`, dot);
+    let outputDir = `./output/${options.outputFile}_export`;
+    await Deno.mkdir(outputDir, {recursive: true});
+    return await Deno.writeTextFile(`${outputDir}/${options.outputFile}_export`, dot);
 }
 
 
 async function exportImage(client, options) {
     let dot = await outputDot(client, options);
     options.outputFile = options.outputFile || genFileNameFromNetworkName(options.accountName, options.format);
-    return await renderDot(dot, `./${options.outputFile}`, {format: options.format});
+    let outputDir = `./output/${options.outputFile}_export`;
+    await Deno.mkdir(outputDir, {recursive: true});
+    return await renderDot(dot, `${outputDir}/${options.outputFile}_export`, {format: options.format});
 }
 
 
@@ -170,8 +174,10 @@ async function exportJson(client, options) {
     const allNodes = await client.fetchAll(configForExport);
 
     setLastConnectedOnUser(allNodes);
-    options.outputFile = options.outputFile || genFileNameFromNetworkName(options.accountName, "json");
-    await Deno.writeTextFile(`./${options.outputFile}`, JSON.stringify(allNodes));
+    options.outputFile = options.outputFile || genFileNameFromNetworkName(options.accountName, options.format);
+    let outputDir = `./output/${options.outputFile}_export`;
+    await Deno.mkdir(outputDir, {recursive: true});
+    await Deno.writeTextFile(`${outputDir}/${options.outputFile}_export.${options.format}`, JSON.stringify(allNodes));
 }
 
 
@@ -203,8 +209,10 @@ async function exportExcel(client, options) {
         ws['!autofilter'] = {ref: ws["!ref"]};
         XLSX.utils.book_append_sheet(wb, ws, typeName);
     }
-    options.outputFile = options.outputFile || genFileNameFromNetworkName(options.accountName);
-    await Deno.writeFile(`./${options.outputFile}`, new Uint8Array(XLSX.write(wb, {type: "array"})));
+    options.outputFile = options.outputFile || genFileNameFromNetworkName(options.accountName, "xlsx");
+    let outputDir = `./output/${options.outputFile}_export`;
+    await Deno.mkdir(outputDir, {recursive: true});
+    await Deno.writeFile(`${outputDir}/${options.outputFile}_export.${options.format}`, new Uint8Array(XLSX.write(wb, {type: "array"})));
 }
 
 

--- a/cliCmd/importCmd.mjs
+++ b/cliCmd/importCmd.mjs
@@ -574,7 +574,7 @@ export const importCmd = new Command()
                                 let securityPolicyId = securityPolicyIdByName(resourceRow.securityPolicyLabel);
                                 let isVisible = (resourceRow.isVisible === "true" || resourceRow.isVisible === "TRUE" || resourceRow.isVisible == undefined || resourceRow.isVisible === true);
                                 let isBrowserShortcutEnabled = (resourceRow.isBrowserShortcutEnabled === "true" || resourceRow.isBrowserShortcutEnabled === "TRUE" || resourceRow.isBrowserShortcutEnabled == undefined || resourceRow.isBrowserShortcutEnabled === true);
-                                let newResource = await client.createResource(resourceRow.addressValue, resourceRow.alias, groupIds, isBrowserShortcutEnabled, isVisible, resourceRow.name, resourceRow._protocol, remoteNetworkId, securityPolicyId);
+                                let newResource = await client.createResource(resourceRow.name, resourceRow.addressValue, remoteNetworkId, resourceRow._protocol, groupIds, resourceRow.alias, isBrowserShortcutEnabled, isVisible, securityPolicyId);
                                 
                                 resourceRow.importId = newResource.id;
                                 delete resourceRow._protocol;

--- a/utils/smallUtilFuncs.mjs
+++ b/utils/smallUtilFuncs.mjs
@@ -9,8 +9,8 @@ import {decryptData, encryptData} from "../crypto.mjs";
 import {Log} from "./log.js";
 import {Input} from "https://deno.land/x/cliffy/prompt/input.ts";
 import {VERSION} from "../version.js";
-import { readerFromStreamReader } from "https://deno.land/std/io/mod.ts";
-
+//import { readerFromStreamReader } from "https://deno.land/std/io/mod.ts";
+import { readerFromStreamReader } from "https://deno.land/std@0.201.0/streams/mod.ts";
 
 
 export function genFileNameFromNetworkName(networkName, extension = "xlsx") {
@@ -18,7 +18,7 @@ export function genFileNameFromNetworkName(networkName, extension = "xlsx") {
         d = new Date(),
         date = d.toISOString().split('T')[0],
         time = (d.toTimeString().split(' ')[0]).replaceAll(":", "-");
-    return `${networkName}-${date}_${time}.${extension}`;
+    return `${date}_${time}_${networkName}`;
 }
 
 export async function loadClientForCLI(options) {


### PR DESCRIPTION
## Bulk update/create Resources from Excel
### Functionality: a means to allow admins to bulk update/create resources from excel. 
**Example:**
1. `./tg export` - by default, exports the admin's tenant into an xlsx file
2. The admin can go in and adjust most _(see limitations below)_ cells for bulk configuration changes, and save the file.
3. `./tg import -f <xlsx-file>` - will import the saved configuration changes and attempt to either (a) update the existing resource or (b) create a new resource

### Explanation of changes:
**TwingateApiClient.mjs:**
- Expanded resource fields - although `groups` and `serviceAccounts` is now deprecated for the `access` connection, there doesn't seem to be consistency across the API so I left as is _(FRs that need to be requested below)_.
- Updated `createResource()` for expanded functionality with the mutation
- Created `updateResource()` to allow bulk update functionality with the mutation

**smallUtilFuncs.mjs:** 
- `readerFromStreamReader` seems to be deprecated, temporarily updated module to the last working version (not familiar enough with a path forward - @chenbishop?)
- updated `genFileNameFromNetworkName()` to accommodate new output folder so import/export files aren't dropped in main directory

**importCmd.mjs:**
- expanded functionality to support new `updateResource()`
- expanded functionality to support updated `createResource()`
- Added an `outputDir` so import files aren't dropped in main directory

**exportCmd.mjs:**
- Added an `outputDir` so export files aren't dropped in main directory

### Instructions/Limitations & FRs needed:
**Instructions/Limitations:**
- Creating a resource:
  - A resource will be created if an existing Id is not found **AND** must have (a) `name`, (b) `remoteNetworkLabel`, and (c) `addressValue` specified.
  _- `serviceAccounts` will not get updated as there is currently no argument available for `resourceCreate` mutation._
  _- `isActive` will not get updated as there is currently no argument available for `resourceCreate`._
- Updating a resource:
  - A resource will instead be updated if an existing Id is found **AND** (a) `name`, (b) `remoteNetworkLabel`, and (c) `addressValue` are specified.
  _- `serviceAccounts` will not get updated as there is currently no argument available for `resourceUpdate`._

**FRs needed:**
- `resourceUpdate` Mutation
  - needs `serviceAccounts ([])` - or the new `access{serviceAccounts, groupIds}`
- `resourceCreate` Mutation
  - needs `isActive (boolean)`
  - needs `serviceAccounts ([])` - or goes off the new `access{serviceAccounts, groupIds}`